### PR TITLE
fix: resolve ty check typing failure in dataset loaders

### DIFF
--- a/nano_gpt/datasets/finewebedu.py
+++ b/nano_gpt/datasets/finewebedu.py
@@ -8,7 +8,6 @@ See https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu
 
 import logging
 
-from typing import cast
 import datasets
 
 from nano_gpt.config import TrainDataset
@@ -36,14 +35,11 @@ def load_dataset(split: str, streaming: bool = True) -> datasets.Dataset:
         raise ValueError(
             f"Invalid split: {split}. Must be one of {list(_SPLITS.keys())}."
         )
-    return cast(
-        datasets.Dataset,
-        datasets.load_dataset(
-            "HuggingFaceFW/fineweb-edu",
-            name="sample-10BT",
-            streaming=streaming,
-            split=_SPLITS[split],
-        ),
+    return datasets.load_dataset(  # type: ignore[ty:invalid-return-type]
+        "HuggingFaceFW/fineweb-edu",
+        name="sample-10BT",
+        streaming=streaming,
+        split=_SPLITS[split],
     )
 
 

--- a/nano_gpt/datasets/tinyshakespeare.py
+++ b/nano_gpt/datasets/tinyshakespeare.py
@@ -3,7 +3,6 @@
 This is a thin wrapper around the HuggingFace datasets library.
 """
 
-from typing import cast
 import datasets
 
 from nano_gpt.config import TrainDataset
@@ -20,9 +19,8 @@ def load_dataset(split: str, streaming: bool = True) -> datasets.Dataset:
 
     Streaming flag is ignored because the tinyshakespeare dataset is small.
     """
-    return cast(
-        datasets.Dataset,
-        datasets.load_dataset("tiny_shakespeare", trust_remote_code=True, split=split),
+    return datasets.load_dataset(
+        "tiny_shakespeare", trust_remote_code=True, split=split
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,8 @@ warn_unreachable = true
 
 [tool.codespell]
 skip = "*.ipynb"
+
+[tool.ty.src]
+exclude = [
+  "**/*.ipynb",
+]


### PR DESCRIPTION
This PR fixes the `ty check` typing failures in the dataset loader modules:
- Removes redundant cast in `nano_gpt/datasets/tinyshakespeare.py`.
- Adds inline type ignore for `invalid-return-type` in `nano_gpt/datasets/finewebedu.py` due to third-party library typing stub limitations.
- Removes unused imports of `cast`.
- Excludes Jupyter notebooks (`**/*.ipynb`) from `ty` check in `pyproject.toml` (aligning with `run-ty.sh` behavior).